### PR TITLE
Refactor to allow charts to accept values as React props

### DIFF
--- a/examples/app.js
+++ b/examples/app.js
@@ -2,9 +2,10 @@
 
 import React, { Component } from 'react';
 
-import LegendExample from './components/example-legend.jsx';
+import AreaChartExample from './components/example-areachart.jsx';
 import BarChartExample from './components/example-barchart';
 import ChoroplethExample from './components/example-choropleth';
+import LegendExample from './components/example-legend.jsx';
 import PunchcardExample from './components/example-punchcard.jsx';
 
 class App extends Component {
@@ -15,12 +16,14 @@ class App extends Component {
       <div>
         <h1>Panorama Toolkit examples</h1>
         <hr />
-        <h2>Legend</h2>
-        <LegendExample/>
-        <h2>Barchart</h2>
+        <h2>Area Chart</h2>
+        <AreaChartExample/>
+        <h2>Bar Chart</h2>
         <BarChartExample/>
         <h2>Choropleth</h2>
         <ChoroplethExample/>
+        <h2>Legend</h2>
+        <LegendExample/>
         <h2>Punchcard</h2>
         <PunchcardExample/>
       </div>

--- a/examples/components/example-areachart.jsx
+++ b/examples/components/example-areachart.jsx
@@ -1,0 +1,58 @@
+import * as React from 'react';
+import { AreaChart } from '../../src/main';
+
+export default class AreaChartExample extends React.Component {
+
+  constructor () {
+
+    super();
+
+  }
+
+  render () {
+
+    const MIN_YEAR = 1820;
+    const MAX_YEAR = 1860;
+    const MIN_VALUE = 0;
+    const MAX_VALUE = 4000000;
+
+    let areaChartConfig = {
+      data: require('../data/areaChart.json'),
+      // data: _.values(CommodityStore.getAllCommodities()).map(v => _.values(v)),  // TODO: we will want commodities for all canals...
+      // data: [_.values(CommodityStore.getAllCommodities()[data.selectedCanal.id])],  // ...but for now let's just grab the selected canal.
+
+      width: 600,
+      height: 200,
+
+      // Optionally specify custom margins
+      margin: {top: 20, right: 30, bottom: 20, left: 60},
+
+      // Optionally specify accessors to match your data format
+      xAccessor: d => d.year,
+      yAccessor: d => d.totalNormalizedValue || 0,
+
+      // Optionally specify custom scales
+      xScale: d3.scale.linear()
+        .domain([MIN_YEAR, MAX_YEAR]),
+      yScale: d3.scale.linear()
+        .domain([MIN_VALUE, MAX_VALUE])
+    };
+
+    let offsetAreaChartConfig = {
+      // TODO
+    };
+
+    return (
+      <div>
+        <h4>AreaChart</h4>
+        <AreaChart {...areaChartConfig}/>
+        {/*
+        <h4>OffsetAreaChart</h4>
+        <OffsetAreaChart {...offsetAreaChartConfig}/>
+        */}
+      </div>
+    );
+
+  }
+
+}

--- a/examples/components/example-barchart.jsx
+++ b/examples/components/example-barchart.jsx
@@ -19,31 +19,31 @@ export default class BarchartExample extends React.Component {
       ],
       width: 400,
       height: 400
-      // xAccessor: d => d.key,
-      // yAccessor: d => d.value
     };
 
     var opts2 = {
       data: [
-        { key: 'red', value: 20 },
-        { key: 'blue', value: 40 },
-        { key: 'green', value: 10 }
+        { colorName: 'red', amount: 20 },
+        { colorName: 'blue', amount: 40 },
+        { colorName: 'green', amount: 10 }
       ],
       width: 600,
       height: 200,
-      margin: { top: 20, right: 30, bottom: 20, left: 50 }
-      // xAccessor: d => d.value,
-      // yAccessor: d => d.key
+
+      // Optionally specify custom margins
+      margin: { top: 20, right: 30, bottom: 20, left: 50 },
+
+      // Optionally specify accessors to match your data format
+      xAccessor: d => d.amount,
+      yAccessor: d => d.colorName
     };
 
     return (
       <div>
         <h4>Vertical</h4>
         <DiscreteBarChart key='1' {...opts1}/>
-        {/*
         <h4>Horizontal</h4>
         <HorizontalDiscreteBarChart key='2' {...opts2}/>
-        */}
       </div>
     );
 

--- a/examples/components/example-barchart.jsx
+++ b/examples/components/example-barchart.jsx
@@ -4,46 +4,49 @@ import { DiscreteBarChart, HorizontalDiscreteBarChart } from '../../src/main';
 export default class BarchartExample extends React.Component {
 
   constructor () {
+
     super();
+
   }
 
   render () {
+
     var opts1 = {
       data: [
-        {key: 'red', value: 20},
-        {key: 'blue', value: 40},
-        {key: 'green', value: 10}
+        { key: 'red', value: 20 },
+        { key: 'blue', value: 40 },
+        { key: 'green', value: 10 }
       ],
       width: 400,
-      height: 400,
-      margin: {top: 20, right: 30, bottom: 20, left: 30},
-      barSpacing: 0.1,
-      xAccessor: function(d){return d.key;},
-      yAccessor: function(d){return d.value;}
+      height: 400
+      // xAccessor: d => d.key,
+      // yAccessor: d => d.value
     };
 
     var opts2 = {
       data: [
-        {key: 'red', value: 20},
-        {key: 'blue', value: 40},
-        {key: 'green', value: 10}
+        { key: 'red', value: 20 },
+        { key: 'blue', value: 40 },
+        { key: 'green', value: 10 }
       ],
       width: 600,
       height: 200,
-      margin: {top: 20, right: 30, bottom: 20, left: 50},
-      barSpacing: 0.1,
-      xAccessor: function(d){return d.value;},
-      yAccessor: function(d){return d.key;}
+      margin: { top: 20, right: 30, bottom: 20, left: 50 }
+      // xAccessor: d => d.value,
+      // yAccessor: d => d.key
     };
 
     return (
       <div>
         <h4>Vertical</h4>
         <DiscreteBarChart key='1' {...opts1}/>
+        {/*
         <h4>Horizontal</h4>
         <HorizontalDiscreteBarChart key='2' {...opts2}/>
+        */}
       </div>
     );
+
   }
 
 }

--- a/examples/components/example-choropleth.jsx
+++ b/examples/components/example-choropleth.jsx
@@ -16,17 +16,21 @@ export default class ChoroplethExample extends React.Component {
   }
 
   render () {
+
     var vals = new Map();
-    mapValues.map(function(r){
+
+    mapValues.map(r => {
       vals.set(r.id, r.rate);
     });
+    
     var data = {
       geometry: topojson.feature(geodata, geodata.objects.counties),
       values: vals
     };
+
     return (
       <div>
-        {/*<MapChoropleth data={data}/>*/}
+        <MapChoropleth data={data}/>
       </div>
     );
 

--- a/examples/components/example-choropleth.jsx
+++ b/examples/components/example-choropleth.jsx
@@ -26,7 +26,7 @@ export default class ChoroplethExample extends React.Component {
     };
     return (
       <div>
-        <MapChoropleth data={data}/>
+        {/*<MapChoropleth data={data}/>*/}
       </div>
     );
 

--- a/examples/data/areaChart.json
+++ b/examples/data/areaChart.json
@@ -1,0 +1,1526 @@
+[
+  [
+    {
+      "year": 1825,
+      "commodities": {
+        "229": {
+          "id": 229,
+          "name": "Coal",
+          "value": 6500,
+          "normalizedValue": 6500
+        }
+      },
+      "commodityCategories": {
+        "5": {
+          "commodities": [
+            {
+              "id": 229,
+              "name": "Coal",
+              "value": 6500,
+              "normalizedValue": 6500
+            }
+          ],
+          "name": "Fuel and Ore",
+          "aggregateNormalizedValue": 6500
+        }
+      },
+      "totalNormalizedValue": null
+    },
+    {
+      "year": 1826,
+      "commodities": {
+        "158": {
+          "id": 158,
+          "name": "Miscellaneous\/Other Articles",
+          "value": 15637,
+          "normalizedValue": 15637
+        },
+        "229": {
+          "id": 229,
+          "name": "Coal",
+          "value": 16767,
+          "normalizedValue": 16767
+        }
+      },
+      "commodityCategories": {
+        "5": {
+          "commodities": [
+            {
+              "id": 229,
+              "name": "Coal",
+              "value": 16767,
+              "normalizedValue": 16767
+            }
+          ],
+          "name": "Fuel and Ore",
+          "aggregateNormalizedValue": 16767
+        },
+        "8": {
+          "commodities": [
+            {
+              "id": 158,
+              "name": "Miscellaneous\/Other Articles",
+              "value": 15637,
+              "normalizedValue": 15637
+            }
+          ],
+          "name": "Other Articles",
+          "aggregateNormalizedValue": 15637
+        }
+      },
+      "totalNormalizedValue": 32404
+    },
+    {
+      "year": 1827,
+      "commodities": {
+        "158": {
+          "id": 158,
+          "name": "Miscellaneous\/Other Articles",
+          "value": 33871,
+          "normalizedValue": 33871
+        },
+        "229": {
+          "id": 229,
+          "name": "Coal",
+          "value": 31630,
+          "normalizedValue": 31630
+        }
+      },
+      "commodityCategories": {
+        "5": {
+          "commodities": [
+            {
+              "id": 229,
+              "name": "Coal",
+              "value": 31630,
+              "normalizedValue": 31630
+            }
+          ],
+          "name": "Fuel and Ore",
+          "aggregateNormalizedValue": 31630
+        },
+        "8": {
+          "commodities": [
+            {
+              "id": 158,
+              "name": "Miscellaneous\/Other Articles",
+              "value": 33871,
+              "normalizedValue": 33871
+            }
+          ],
+          "name": "Other Articles",
+          "aggregateNormalizedValue": 33871
+        }
+      },
+      "totalNormalizedValue": 65501
+    },
+    {
+      "year": 1828,
+      "commodities": {
+        "158": {
+          "id": 158,
+          "name": "Miscellaneous\/Other Articles",
+          "value": 58179,
+          "normalizedValue": 58179
+        },
+        "229": {
+          "id": 229,
+          "name": "Coal",
+          "value": 47284,
+          "normalizedValue": 47284
+        }
+      },
+      "commodityCategories": {
+        "5": {
+          "commodities": [
+            {
+              "id": 229,
+              "name": "Coal",
+              "value": 47284,
+              "normalizedValue": 47284
+            }
+          ],
+          "name": "Fuel and Ore",
+          "aggregateNormalizedValue": 47284
+        },
+        "8": {
+          "commodities": [
+            {
+              "id": 158,
+              "name": "Miscellaneous\/Other Articles",
+              "value": 58179,
+              "normalizedValue": 58179
+            }
+          ],
+          "name": "Other Articles",
+          "aggregateNormalizedValue": 58179
+        }
+      },
+      "totalNormalizedValue": 105463
+    },
+    {
+      "year": 1829,
+      "commodities": {
+        "158": {
+          "id": 158,
+          "name": "Miscellaneous\/Other Articles",
+          "value": 54551,
+          "normalizedValue": 54551
+        },
+        "229": {
+          "id": 229,
+          "name": "Coal",
+          "value": 79973,
+          "normalizedValue": 79973
+        }
+      },
+      "commodityCategories": {
+        "5": {
+          "commodities": [
+            {
+              "id": 229,
+              "name": "Coal",
+              "value": 79973,
+              "normalizedValue": 79973
+            }
+          ],
+          "name": "Fuel and Ore",
+          "aggregateNormalizedValue": 79973
+        },
+        "8": {
+          "commodities": [
+            {
+              "id": 158,
+              "name": "Miscellaneous\/Other Articles",
+              "value": 54551,
+              "normalizedValue": 54551
+            }
+          ],
+          "name": "Other Articles",
+          "aggregateNormalizedValue": 54551
+        }
+      },
+      "totalNormalizedValue": 134524
+    },
+    {
+      "year": 1830,
+      "commodities": {
+        "158": {
+          "id": 158,
+          "name": "Miscellaneous\/Other Articles",
+          "value": 90771,
+          "normalizedValue": 90771
+        },
+        "229": {
+          "id": 229,
+          "name": "Coal",
+          "value": 89984,
+          "normalizedValue": 89984
+        }
+      },
+      "commodityCategories": {
+        "5": {
+          "commodities": [
+            {
+              "id": 229,
+              "name": "Coal",
+              "value": 89984,
+              "normalizedValue": 89984
+            }
+          ],
+          "name": "Fuel and Ore",
+          "aggregateNormalizedValue": 89984
+        },
+        "8": {
+          "commodities": [
+            {
+              "id": 158,
+              "name": "Miscellaneous\/Other Articles",
+              "value": 90771,
+              "normalizedValue": 90771
+            }
+          ],
+          "name": "Other Articles",
+          "aggregateNormalizedValue": 90771
+        }
+      },
+      "totalNormalizedValue": 180755
+    },
+    {
+      "year": 1831,
+      "commodities": {
+        "158": {
+          "id": 158,
+          "name": "Miscellaneous\/Other Articles",
+          "value": 114559,
+          "normalizedValue": 114559
+        },
+        "229": {
+          "id": 229,
+          "name": "Coal",
+          "value": 81854,
+          "normalizedValue": 81854
+        }
+      },
+      "commodityCategories": {
+        "5": {
+          "commodities": [
+            {
+              "id": 229,
+              "name": "Coal",
+              "value": 81854,
+              "normalizedValue": 81854
+            }
+          ],
+          "name": "Fuel and Ore",
+          "aggregateNormalizedValue": 81854
+        },
+        "8": {
+          "commodities": [
+            {
+              "id": 158,
+              "name": "Miscellaneous\/Other Articles",
+              "value": 114559,
+              "normalizedValue": 114559
+            }
+          ],
+          "name": "Other Articles",
+          "aggregateNormalizedValue": 114559
+        }
+      },
+      "totalNormalizedValue": 196413
+    },
+    {
+      "year": 1832,
+      "commodities": {
+        "158": {
+          "id": 158,
+          "name": "Miscellaneous\/Other Articles",
+          "value": 118650,
+          "normalizedValue": 118650
+        },
+        "229": {
+          "id": 229,
+          "name": "Coal",
+          "value": 209271,
+          "normalizedValue": 209271
+        }
+      },
+      "commodityCategories": {
+        "5": {
+          "commodities": [
+            {
+              "id": 229,
+              "name": "Coal",
+              "value": 209271,
+              "normalizedValue": 209271
+            }
+          ],
+          "name": "Fuel and Ore",
+          "aggregateNormalizedValue": 209271
+        },
+        "8": {
+          "commodities": [
+            {
+              "id": 158,
+              "name": "Miscellaneous\/Other Articles",
+              "value": 118650,
+              "normalizedValue": 118650
+            }
+          ],
+          "name": "Other Articles",
+          "aggregateNormalizedValue": 118650
+        }
+      },
+      "totalNormalizedValue": 327921
+    },
+    {
+      "year": 1833,
+      "commodities": {
+        "158": {
+          "id": 158,
+          "name": "Miscellaneous\/Other Articles",
+          "value": 192878,
+          "normalizedValue": 192878
+        },
+        "229": {
+          "id": 229,
+          "name": "Coal",
+          "value": 252971,
+          "normalizedValue": 252971
+        }
+      },
+      "commodityCategories": {
+        "5": {
+          "commodities": [
+            {
+              "id": 229,
+              "name": "Coal",
+              "value": 252971,
+              "normalizedValue": 252971
+            }
+          ],
+          "name": "Fuel and Ore",
+          "aggregateNormalizedValue": 252971
+        },
+        "8": {
+          "commodities": [
+            {
+              "id": 158,
+              "name": "Miscellaneous\/Other Articles",
+              "value": 192878,
+              "normalizedValue": 192878
+            }
+          ],
+          "name": "Other Articles",
+          "aggregateNormalizedValue": 192878
+        }
+      },
+      "totalNormalizedValue": 445849
+    },
+    {
+      "year": 1834,
+      "commodities": {
+        "158": {
+          "id": 158,
+          "name": "Miscellaneous\/Other Articles",
+          "value": 169028,
+          "normalizedValue": 169028
+        },
+        "229": {
+          "id": 229,
+          "name": "Coal",
+          "value": 226692,
+          "normalizedValue": 226692
+        }
+      },
+      "commodityCategories": {
+        "5": {
+          "commodities": [
+            {
+              "id": 229,
+              "name": "Coal",
+              "value": 226692,
+              "normalizedValue": 226692
+            }
+          ],
+          "name": "Fuel and Ore",
+          "aggregateNormalizedValue": 226692
+        },
+        "8": {
+          "commodities": [
+            {
+              "id": 158,
+              "name": "Miscellaneous\/Other Articles",
+              "value": 169028,
+              "normalizedValue": 169028
+            }
+          ],
+          "name": "Other Articles",
+          "aggregateNormalizedValue": 169028
+        }
+      },
+      "totalNormalizedValue": 395720
+    },
+    {
+      "year": 1835,
+      "commodities": {
+        "158": {
+          "id": 158,
+          "name": "Miscellaneous\/Other Articles",
+          "value": 195686,
+          "normalizedValue": 195686
+        },
+        "229": {
+          "id": 229,
+          "name": "Coal",
+          "value": 339508,
+          "normalizedValue": 339508
+        }
+      },
+      "commodityCategories": {
+        "5": {
+          "commodities": [
+            {
+              "id": 229,
+              "name": "Coal",
+              "value": 339508,
+              "normalizedValue": 339508
+            }
+          ],
+          "name": "Fuel and Ore",
+          "aggregateNormalizedValue": 339508
+        },
+        "8": {
+          "commodities": [
+            {
+              "id": 158,
+              "name": "Miscellaneous\/Other Articles",
+              "value": 195686,
+              "normalizedValue": 195686
+            }
+          ],
+          "name": "Other Articles",
+          "aggregateNormalizedValue": 195686
+        }
+      },
+      "totalNormalizedValue": 535194
+    },
+    {
+      "year": 1836,
+      "commodities": {
+        "158": {
+          "id": 158,
+          "name": "Miscellaneous\/Other Articles",
+          "value": 199128,
+          "normalizedValue": 199128
+        },
+        "229": {
+          "id": 229,
+          "name": "Coal",
+          "value": 432045,
+          "normalizedValue": 432045
+        }
+      },
+      "commodityCategories": {
+        "5": {
+          "commodities": [
+            {
+              "id": 229,
+              "name": "Coal",
+              "value": 432045,
+              "normalizedValue": 432045
+            }
+          ],
+          "name": "Fuel and Ore",
+          "aggregateNormalizedValue": 432045
+        },
+        "8": {
+          "commodities": [
+            {
+              "id": 158,
+              "name": "Miscellaneous\/Other Articles",
+              "value": 199128,
+              "normalizedValue": 199128
+            }
+          ],
+          "name": "Other Articles",
+          "aggregateNormalizedValue": 199128
+        }
+      },
+      "totalNormalizedValue": 631173
+    },
+    {
+      "year": 1837,
+      "commodities": {
+        "158": {
+          "id": 158,
+          "name": "Miscellaneous\/Other Articles",
+          "value": 203578,
+          "normalizedValue": 203578
+        },
+        "229": {
+          "id": 229,
+          "name": "Coal",
+          "value": 523152,
+          "normalizedValue": 523152
+        }
+      },
+      "commodityCategories": {
+        "5": {
+          "commodities": [
+            {
+              "id": 229,
+              "name": "Coal",
+              "value": 523152,
+              "normalizedValue": 523152
+            }
+          ],
+          "name": "Fuel and Ore",
+          "aggregateNormalizedValue": 523152
+        },
+        "8": {
+          "commodities": [
+            {
+              "id": 158,
+              "name": "Miscellaneous\/Other Articles",
+              "value": 203578,
+              "normalizedValue": 203578
+            }
+          ],
+          "name": "Other Articles",
+          "aggregateNormalizedValue": 203578
+        }
+      },
+      "totalNormalizedValue": 726730
+    },
+    {
+      "year": 1838,
+      "commodities": {
+        "158": {
+          "id": 158,
+          "name": "Miscellaneous\/Other Articles",
+          "value": 209758,
+          "normalizedValue": 209758
+        },
+        "229": {
+          "id": 229,
+          "name": "Coal",
+          "value": 433875,
+          "normalizedValue": 433875
+        }
+      },
+      "commodityCategories": {
+        "5": {
+          "commodities": [
+            {
+              "id": 229,
+              "name": "Coal",
+              "value": 433875,
+              "normalizedValue": 433875
+            }
+          ],
+          "name": "Fuel and Ore",
+          "aggregateNormalizedValue": 433875
+        },
+        "8": {
+          "commodities": [
+            {
+              "id": 158,
+              "name": "Miscellaneous\/Other Articles",
+              "value": 209758,
+              "normalizedValue": 209758
+            }
+          ],
+          "name": "Other Articles",
+          "aggregateNormalizedValue": 209758
+        }
+      },
+      "totalNormalizedValue": 643633
+    },
+    {
+      "year": 1839,
+      "commodities": {
+        "158": {
+          "id": 158,
+          "name": "Miscellaneous\/Other Articles",
+          "value": 244108,
+          "normalizedValue": 244108
+        },
+        "229": {
+          "id": 229,
+          "name": "Coal",
+          "value": 442608,
+          "normalizedValue": 442608
+        }
+      },
+      "commodityCategories": {
+        "5": {
+          "commodities": [
+            {
+              "id": 229,
+              "name": "Coal",
+              "value": 442608,
+              "normalizedValue": 442608
+            }
+          ],
+          "name": "Fuel and Ore",
+          "aggregateNormalizedValue": 442608
+        },
+        "8": {
+          "commodities": [
+            {
+              "id": 158,
+              "name": "Miscellaneous\/Other Articles",
+              "value": 244108,
+              "normalizedValue": 244108
+            }
+          ],
+          "name": "Other Articles",
+          "aggregateNormalizedValue": 244108
+        }
+      },
+      "totalNormalizedValue": 686716
+    },
+    {
+      "year": 1840,
+      "commodities": {
+        "158": {
+          "id": 158,
+          "name": "Miscellaneous\/Other Articles",
+          "value": 206253,
+          "normalizedValue": 206253
+        },
+        "229": {
+          "id": 229,
+          "name": "Coal",
+          "value": 452291,
+          "normalizedValue": 452291
+        }
+      },
+      "commodityCategories": {
+        "5": {
+          "commodities": [
+            {
+              "id": 229,
+              "name": "Coal",
+              "value": 452291,
+              "normalizedValue": 452291
+            }
+          ],
+          "name": "Fuel and Ore",
+          "aggregateNormalizedValue": 452291
+        },
+        "8": {
+          "commodities": [
+            {
+              "id": 158,
+              "name": "Miscellaneous\/Other Articles",
+              "value": 206253,
+              "normalizedValue": 206253
+            }
+          ],
+          "name": "Other Articles",
+          "aggregateNormalizedValue": 206253
+        }
+      },
+      "totalNormalizedValue": 658544
+    },
+    {
+      "year": 1841,
+      "commodities": {
+        "158": {
+          "id": 158,
+          "name": "Miscellaneous\/Other Articles",
+          "value": 152825,
+          "normalizedValue": 152825
+        },
+        "229": {
+          "id": 229,
+          "name": "Coal",
+          "value": 584692,
+          "normalizedValue": 584692
+        }
+      },
+      "commodityCategories": {
+        "5": {
+          "commodities": [
+            {
+              "id": 229,
+              "name": "Coal",
+              "value": 584692,
+              "normalizedValue": 584692
+            }
+          ],
+          "name": "Fuel and Ore",
+          "aggregateNormalizedValue": 584692
+        },
+        "8": {
+          "commodities": [
+            {
+              "id": 158,
+              "name": "Miscellaneous\/Other Articles",
+              "value": 152825,
+              "normalizedValue": 152825
+            }
+          ],
+          "name": "Other Articles",
+          "aggregateNormalizedValue": 152825
+        }
+      },
+      "totalNormalizedValue": 737517
+    },
+    {
+      "year": 1842,
+      "commodities": {
+        "158": {
+          "id": 158,
+          "name": "Miscellaneous\/Other Articles",
+          "value": 152096,
+          "normalizedValue": 152096
+        },
+        "229": {
+          "id": 229,
+          "name": "Coal",
+          "value": 491602,
+          "normalizedValue": 491602
+        }
+      },
+      "commodityCategories": {
+        "5": {
+          "commodities": [
+            {
+              "id": 229,
+              "name": "Coal",
+              "value": 491602,
+              "normalizedValue": 491602
+            }
+          ],
+          "name": "Fuel and Ore",
+          "aggregateNormalizedValue": 491602
+        },
+        "8": {
+          "commodities": [
+            {
+              "id": 158,
+              "name": "Miscellaneous\/Other Articles",
+              "value": 152096,
+              "normalizedValue": 152096
+            }
+          ],
+          "name": "Other Articles",
+          "aggregateNormalizedValue": 152096
+        }
+      },
+      "totalNormalizedValue": 643698
+    },
+    {
+      "year": 1843,
+      "commodities": {
+        "158": {
+          "id": 158,
+          "name": "Miscellaneous\/Other Articles",
+          "value": 146348,
+          "normalizedValue": 146348
+        },
+        "229": {
+          "id": 229,
+          "name": "Coal",
+          "value": 447058,
+          "normalizedValue": 447058
+        }
+      },
+      "commodityCategories": {
+        "5": {
+          "commodities": [
+            {
+              "id": 229,
+              "name": "Coal",
+              "value": 447058,
+              "normalizedValue": 447058
+            }
+          ],
+          "name": "Fuel and Ore",
+          "aggregateNormalizedValue": 447058
+        },
+        "8": {
+          "commodities": [
+            {
+              "id": 158,
+              "name": "Miscellaneous\/Other Articles",
+              "value": 146348,
+              "normalizedValue": 146348
+            }
+          ],
+          "name": "Other Articles",
+          "aggregateNormalizedValue": 146348
+        }
+      },
+      "totalNormalizedValue": 593406
+    },
+    {
+      "year": 1844,
+      "commodities": {
+        "158": {
+          "id": 158,
+          "name": "Miscellaneous\/Other Articles",
+          "value": 174584,
+          "normalizedValue": 174584
+        },
+        "229": {
+          "id": 229,
+          "name": "Coal",
+          "value": 398887,
+          "normalizedValue": 398887
+        }
+      },
+      "commodityCategories": {
+        "5": {
+          "commodities": [
+            {
+              "id": 229,
+              "name": "Coal",
+              "value": 398887,
+              "normalizedValue": 398887
+            }
+          ],
+          "name": "Fuel and Ore",
+          "aggregateNormalizedValue": 398887
+        },
+        "8": {
+          "commodities": [
+            {
+              "id": 158,
+              "name": "Miscellaneous\/Other Articles",
+              "value": 174584,
+              "normalizedValue": 174584
+            }
+          ],
+          "name": "Other Articles",
+          "aggregateNormalizedValue": 174584
+        }
+      },
+      "totalNormalizedValue": 573471
+    },
+    {
+      "year": 1845,
+      "commodities": {
+        "158": {
+          "id": 158,
+          "name": "Miscellaneous\/Other Articles",
+          "value": 204155,
+          "normalizedValue": 204155
+        },
+        "229": {
+          "id": 229,
+          "name": "Coal",
+          "value": 263587,
+          "normalizedValue": 263587
+        }
+      },
+      "commodityCategories": {
+        "5": {
+          "commodities": [
+            {
+              "id": 229,
+              "name": "Coal",
+              "value": 263587,
+              "normalizedValue": 263587
+            }
+          ],
+          "name": "Fuel and Ore",
+          "aggregateNormalizedValue": 263587
+        },
+        "8": {
+          "commodities": [
+            {
+              "id": 158,
+              "name": "Miscellaneous\/Other Articles",
+              "value": 204155,
+              "normalizedValue": 204155
+            }
+          ],
+          "name": "Other Articles",
+          "aggregateNormalizedValue": 204155
+        }
+      },
+      "totalNormalizedValue": 467742
+    },
+    {
+      "year": 1846,
+      "commodities": {
+        "158": {
+          "id": 158,
+          "name": "Miscellaneous\/Other Articles",
+          "value": 105351,
+          "normalizedValue": 105351
+        },
+        "229": {
+          "id": 229,
+          "name": "Coal",
+          "value": 3437,
+          "normalizedValue": 3437
+        }
+      },
+      "commodityCategories": {
+        "5": {
+          "commodities": [
+            {
+              "id": 229,
+              "name": "Coal",
+              "value": 3437,
+              "normalizedValue": 3437
+            }
+          ],
+          "name": "Fuel and Ore",
+          "aggregateNormalizedValue": 3437
+        },
+        "8": {
+          "commodities": [
+            {
+              "id": 158,
+              "name": "Miscellaneous\/Other Articles",
+              "value": 105351,
+              "normalizedValue": 105351
+            }
+          ],
+          "name": "Other Articles",
+          "aggregateNormalizedValue": 105351
+        }
+      },
+      "totalNormalizedValue": 108788
+    },
+    {
+      "year": 1847,
+      "commodities": {
+        "158": {
+          "id": 158,
+          "name": "Miscellaneous\/Other Articles",
+          "value": 209704,
+          "normalizedValue": 209704
+        },
+        "229": {
+          "id": 229,
+          "name": "Coal",
+          "value": 222693,
+          "normalizedValue": 222693
+        }
+      },
+      "commodityCategories": {
+        "5": {
+          "commodities": [
+            {
+              "id": 229,
+              "name": "Coal",
+              "value": 222693,
+              "normalizedValue": 222693
+            }
+          ],
+          "name": "Fuel and Ore",
+          "aggregateNormalizedValue": 222693
+        },
+        "8": {
+          "commodities": [
+            {
+              "id": 158,
+              "name": "Miscellaneous\/Other Articles",
+              "value": 209704,
+              "normalizedValue": 209704
+            }
+          ],
+          "name": "Other Articles",
+          "aggregateNormalizedValue": 209704
+        }
+      },
+      "totalNormalizedValue": 432397
+    },
+    {
+      "year": 1848,
+      "commodities": {
+        "158": {
+          "id": 158,
+          "name": "Miscellaneous\/Other Articles",
+          "value": 242972,
+          "normalizedValue": 242972
+        },
+        "229": {
+          "id": 229,
+          "name": "Coal",
+          "value": 436602,
+          "normalizedValue": 436602
+        }
+      },
+      "commodityCategories": {
+        "5": {
+          "commodities": [
+            {
+              "id": 229,
+              "name": "Coal",
+              "value": 436602,
+              "normalizedValue": 436602
+            }
+          ],
+          "name": "Fuel and Ore",
+          "aggregateNormalizedValue": 436602
+        },
+        "8": {
+          "commodities": [
+            {
+              "id": 158,
+              "name": "Miscellaneous\/Other Articles",
+              "value": 242972,
+              "normalizedValue": 242972
+            }
+          ],
+          "name": "Other Articles",
+          "aggregateNormalizedValue": 242972
+        }
+      },
+      "totalNormalizedValue": 679574
+    },
+    {
+      "year": 1849,
+      "commodities": {
+        "158": {
+          "id": 158,
+          "name": "Miscellaneous\/Other Articles",
+          "value": 222317,
+          "normalizedValue": 222317
+        },
+        "229": {
+          "id": 229,
+          "name": "Coal",
+          "value": 489208,
+          "normalizedValue": 489208
+        }
+      },
+      "commodityCategories": {
+        "5": {
+          "commodities": [
+            {
+              "id": 229,
+              "name": "Coal",
+              "value": 489208,
+              "normalizedValue": 489208
+            }
+          ],
+          "name": "Fuel and Ore",
+          "aggregateNormalizedValue": 489208
+        },
+        "8": {
+          "commodities": [
+            {
+              "id": 158,
+              "name": "Miscellaneous\/Other Articles",
+              "value": 222317,
+              "normalizedValue": 222317
+            }
+          ],
+          "name": "Other Articles",
+          "aggregateNormalizedValue": 222317
+        }
+      },
+      "totalNormalizedValue": 711525
+    },
+    {
+      "year": 1850,
+      "commodities": {
+        "158": {
+          "id": 158,
+          "name": "Miscellaneous\/Other Articles",
+          "value": 170019,
+          "normalizedValue": 170019
+        },
+        "229": {
+          "id": 229,
+          "name": "Coal",
+          "value": 288030,
+          "normalizedValue": 288030
+        }
+      },
+      "commodityCategories": {
+        "5": {
+          "commodities": [
+            {
+              "id": 229,
+              "name": "Coal",
+              "value": 288030,
+              "normalizedValue": 288030
+            }
+          ],
+          "name": "Fuel and Ore",
+          "aggregateNormalizedValue": 288030
+        },
+        "8": {
+          "commodities": [
+            {
+              "id": 158,
+              "name": "Miscellaneous\/Other Articles",
+              "value": 170019,
+              "normalizedValue": 170019
+            }
+          ],
+          "name": "Other Articles",
+          "aggregateNormalizedValue": 170019
+        }
+      },
+      "totalNormalizedValue": 458049
+    },
+    {
+      "year": 1851,
+      "commodities": {
+        "158": {
+          "id": 158,
+          "name": "Miscellaneous\/Other Articles",
+          "value": 362941,
+          "normalizedValue": 362941
+        },
+        "229": {
+          "id": 229,
+          "name": "Coal",
+          "value": 579156,
+          "normalizedValue": 579156
+        }
+      },
+      "commodityCategories": {
+        "5": {
+          "commodities": [
+            {
+              "id": 229,
+              "name": "Coal",
+              "value": 579156,
+              "normalizedValue": 579156
+            }
+          ],
+          "name": "Fuel and Ore",
+          "aggregateNormalizedValue": 579156
+        },
+        "8": {
+          "commodities": [
+            {
+              "id": 158,
+              "name": "Miscellaneous\/Other Articles",
+              "value": 362941,
+              "normalizedValue": 362941
+            }
+          ],
+          "name": "Other Articles",
+          "aggregateNormalizedValue": 362941
+        }
+      },
+      "totalNormalizedValue": 942097
+    },
+    {
+      "year": 1852,
+      "commodities": {
+        "158": {
+          "id": 158,
+          "name": "Miscellaneous\/Other Articles",
+          "value": 274061,
+          "normalizedValue": 274061
+        },
+        "229": {
+          "id": 229,
+          "name": "Coal",
+          "value": 800638,
+          "normalizedValue": 800638
+        }
+      },
+      "commodityCategories": {
+        "5": {
+          "commodities": [
+            {
+              "id": 229,
+              "name": "Coal",
+              "value": 800638,
+              "normalizedValue": 800638
+            }
+          ],
+          "name": "Fuel and Ore",
+          "aggregateNormalizedValue": 800638
+        },
+        "8": {
+          "commodities": [
+            {
+              "id": 158,
+              "name": "Miscellaneous\/Other Articles",
+              "value": 274061,
+              "normalizedValue": 274061
+            }
+          ],
+          "name": "Other Articles",
+          "aggregateNormalizedValue": 274061
+        }
+      },
+      "totalNormalizedValue": 1074699
+    },
+    {
+      "year": 1853,
+      "commodities": {
+        "158": {
+          "id": 158,
+          "name": "Miscellaneous\/Other Articles",
+          "value": 327295,
+          "normalizedValue": 327295
+        },
+        "229": {
+          "id": 229,
+          "name": "Coal",
+          "value": 888695,
+          "normalizedValue": 888695
+        }
+      },
+      "commodityCategories": {
+        "5": {
+          "commodities": [
+            {
+              "id": 229,
+              "name": "Coal",
+              "value": 888695,
+              "normalizedValue": 888695
+            }
+          ],
+          "name": "Fuel and Ore",
+          "aggregateNormalizedValue": 888695
+        },
+        "8": {
+          "commodities": [
+            {
+              "id": 158,
+              "name": "Miscellaneous\/Other Articles",
+              "value": 327295,
+              "normalizedValue": 327295
+            }
+          ],
+          "name": "Other Articles",
+          "aggregateNormalizedValue": 327295
+        }
+      },
+      "totalNormalizedValue": 1215990
+    },
+    {
+      "year": 1854,
+      "commodities": {
+        "158": {
+          "id": 158,
+          "name": "Miscellaneous\/Other Articles",
+          "value": 311144,
+          "normalizedValue": 311144
+        },
+        "229": {
+          "id": 229,
+          "name": "Coal",
+          "value": 907354,
+          "normalizedValue": 907354
+        }
+      },
+      "commodityCategories": {
+        "5": {
+          "commodities": [
+            {
+              "id": 229,
+              "name": "Coal",
+              "value": 907354,
+              "normalizedValue": 907354
+            }
+          ],
+          "name": "Fuel and Ore",
+          "aggregateNormalizedValue": 907354
+        },
+        "8": {
+          "commodities": [
+            {
+              "id": 158,
+              "name": "Miscellaneous\/Other Articles",
+              "value": 311144,
+              "normalizedValue": 311144
+            }
+          ],
+          "name": "Other Articles",
+          "aggregateNormalizedValue": 311144
+        }
+      },
+      "totalNormalizedValue": 1218498
+    },
+    {
+      "year": 1855,
+      "commodities": {
+        "158": {
+          "id": 158,
+          "name": "Miscellaneous\/Other Articles",
+          "value": 291230,
+          "normalizedValue": 291230
+        },
+        "229": {
+          "id": 229,
+          "name": "Coal",
+          "value": 1105263,
+          "normalizedValue": 1105263
+        }
+      },
+      "commodityCategories": {
+        "5": {
+          "commodities": [
+            {
+              "id": 229,
+              "name": "Coal",
+              "value": 1105263,
+              "normalizedValue": 1105263
+            }
+          ],
+          "name": "Fuel and Ore",
+          "aggregateNormalizedValue": 1105263
+        },
+        "8": {
+          "commodities": [
+            {
+              "id": 158,
+              "name": "Miscellaneous\/Other Articles",
+              "value": 291230,
+              "normalizedValue": 291230
+            }
+          ],
+          "name": "Other Articles",
+          "aggregateNormalizedValue": 291230
+        }
+      },
+      "totalNormalizedValue": 1396493
+    },
+    {
+      "year": 1856,
+      "commodities": {
+        "158": {
+          "id": 158,
+          "name": "Miscellaneous\/Other Articles",
+          "value": 279558,
+          "normalizedValue": 279558
+        },
+        "229": {
+          "id": 229,
+          "name": "Coal",
+          "value": 1169453,
+          "normalizedValue": 1169453
+        }
+      },
+      "commodityCategories": {
+        "5": {
+          "commodities": [
+            {
+              "id": 229,
+              "name": "Coal",
+              "value": 1169453,
+              "normalizedValue": 1169453
+            }
+          ],
+          "name": "Fuel and Ore",
+          "aggregateNormalizedValue": 1169453
+        },
+        "8": {
+          "commodities": [
+            {
+              "id": 158,
+              "name": "Miscellaneous\/Other Articles",
+              "value": 279558,
+              "normalizedValue": 279558
+            }
+          ],
+          "name": "Other Articles",
+          "aggregateNormalizedValue": 279558
+        }
+      },
+      "totalNormalizedValue": 1449011
+    },
+    {
+      "year": 1857,
+      "commodities": {
+        "158": {
+          "id": 158,
+          "name": "Miscellaneous\/Other Articles",
+          "value": 319520,
+          "normalizedValue": 319520
+        },
+        "229": {
+          "id": 229,
+          "name": "Coal",
+          "value": 1275988,
+          "normalizedValue": 1275988
+        }
+      },
+      "commodityCategories": {
+        "5": {
+          "commodities": [
+            {
+              "id": 229,
+              "name": "Coal",
+              "value": 1275988,
+              "normalizedValue": 1275988
+            }
+          ],
+          "name": "Fuel and Ore",
+          "aggregateNormalizedValue": 1275988
+        },
+        "8": {
+          "commodities": [
+            {
+              "id": 158,
+              "name": "Miscellaneous\/Other Articles",
+              "value": 319520,
+              "normalizedValue": 319520
+            }
+          ],
+          "name": "Other Articles",
+          "aggregateNormalizedValue": 319520
+        }
+      },
+      "totalNormalizedValue": 1595508
+    },
+    {
+      "year": 1858,
+      "commodities": {
+        "158": {
+          "id": 158,
+          "name": "Miscellaneous\/Other Articles",
+          "value": 298866,
+          "normalizedValue": 298866
+        },
+        "229": {
+          "id": 229,
+          "name": "Coal",
+          "value": 1323804,
+          "normalizedValue": 1323804
+        }
+      },
+      "commodityCategories": {
+        "5": {
+          "commodities": [
+            {
+              "id": 229,
+              "name": "Coal",
+              "value": 1323804,
+              "normalizedValue": 1323804
+            }
+          ],
+          "name": "Fuel and Ore",
+          "aggregateNormalizedValue": 1323804
+        },
+        "8": {
+          "commodities": [
+            {
+              "id": 158,
+              "name": "Miscellaneous\/Other Articles",
+              "value": 298866,
+              "normalizedValue": 298866
+            }
+          ],
+          "name": "Other Articles",
+          "aggregateNormalizedValue": 298866
+        }
+      },
+      "totalNormalizedValue": 1622670
+    },
+    {
+      "year": 1859,
+      "commodities": {
+        "158": {
+          "id": 158,
+          "name": "Miscellaneous\/Other Articles",
+          "value": 326992,
+          "normalizedValue": 326992
+        },
+        "229": {
+          "id": 229,
+          "name": "Coal",
+          "value": 1372109,
+          "normalizedValue": 1372109
+        }
+      },
+      "commodityCategories": {
+        "5": {
+          "commodities": [
+            {
+              "id": 229,
+              "name": "Coal",
+              "value": 1372109,
+              "normalizedValue": 1372109
+            }
+          ],
+          "name": "Fuel and Ore",
+          "aggregateNormalizedValue": 1372109
+        },
+        "8": {
+          "commodities": [
+            {
+              "id": 158,
+              "name": "Miscellaneous\/Other Articles",
+              "value": 326992,
+              "normalizedValue": 326992
+            }
+          ],
+          "name": "Other Articles",
+          "aggregateNormalizedValue": 326992
+        }
+      },
+      "totalNormalizedValue": 1699101
+    }
+  ]
+]

--- a/examples/webpack.config.js
+++ b/examples/webpack.config.js
@@ -10,7 +10,7 @@ module.exports = {
 
   debug: process.env.NODE_ENV !== 'production',
 
-  devtool: 'sourcemap',
+  devtool: 'source-map',
 
   devServer: {
     port: WEBSERVER_PORT

--- a/package.json
+++ b/package.json
@@ -31,6 +31,7 @@
   "dependencies": {
     "d3": "^3.5.6",
     "koto": "0.1.3",
+    "lodash": "^3.10.1",
     "react": "^0.14.0",
     "react-dom": "^0.14.0",
     "topojson": "^1.6.19"

--- a/src/AreaChart/AreaChart.jsx
+++ b/src/AreaChart/AreaChart.jsx
@@ -1,0 +1,73 @@
+import d3 from 'd3';
+import ChartBase from '../charts/ChartBase';
+import PanoramaChart from '../charts/PanoramaChart.jsx';
+import './style.scss';
+
+export default class AreaChart extends PanoramaChart {
+  constructor (props) {
+    super(props);
+    this.chartConstructor = AreaChartImpl;
+  }
+
+  getClassSuffix () {
+    return 'area-chart';
+  }
+}
+
+export class AreaChartImpl extends ChartBase {
+
+  constructor (selection, props) {
+
+    super(selection, props);
+
+    let areaGenerator = d3.svg.area()
+      .interpolate('basis')
+      .x(d => this.config('xScale')(this.accessor('x')(d)))
+      .y0(d => this.config('yScale')(0))
+      .y1(d => this.config('yScale')(this.accessor('y')(d)));
+
+
+    // append group to chart
+    var area = this.baseLayer = this.base.append('g').classed('area-layer', true);
+
+    this.updateDimensions();
+
+    // define layer
+    let layer = this.layer('area-layer', area, {
+      dataBind: function (data) {
+        return this.selectAll('path.area').data(data);
+      },
+
+      insert: function () {
+        return this.append('path')
+          .attr('class', 'area');
+      }
+    });
+
+    // Setup life-cycle events on layers
+    layer.on('update', function () {
+      // this => base selection
+      return this
+        .attr('d', d => areaGenerator(d));
+    })
+    .on('enter', function () {
+      // this => enter selection
+      return this
+        .attr('d', d => areaGenerator(d));
+    })
+    .on('merge', function () {
+      // this => base selection
+    })
+    .on('exit', function () {
+      // this => exit selection
+    });
+  }
+  
+  updateScales (data) {
+
+    this.config('xScale').range([0, this._innerWidth]);
+    this.config('yScale').range([this._innerHeight, 0]);
+
+  }
+
+}

--- a/src/AreaChart/style.scss
+++ b/src/AreaChart/style.scss
@@ -1,0 +1,18 @@
+.panorama.area-chart {
+
+  path {
+    fill: steelblue;
+  }
+
+  .axis {
+    font: 10px sans-serif;
+  }
+
+  .axis path,
+  .axis line {
+    fill: none;
+    stroke: #000;
+    shape-rendering: crispEdges;
+  }
+  
+}

--- a/src/DiscreteBarChart/DiscreteBarChart.jsx
+++ b/src/DiscreteBarChart/DiscreteBarChart.jsx
@@ -3,54 +3,45 @@ import PanoramaChart from '../charts/PanoramaChart';
 import ChartBase from '../charts/ChartBase';
 import d3 from 'd3';
 import './style.scss';
-import _ from 'lodash';
 
 export default class DiscreteBarChart extends PanoramaChart {
 
-  // 'inherit' static validators
-  static propTypes = _.merge(PanoramaChart.propTypes, {
+  // extend superclass `props` validators
+  static propTypes = Object.assign({}, PanoramaChart.propTypes, {
     barSpacing: PropTypes.number
   });
 
-  // 'inherit' static defaults
-  static defaultProps = _.merge(PanoramaChart.defaultProps, {
+  // extend superclass `props` defaults
+  static defaultProps = Object.assign({}, PanoramaChart.defaultProps, {
     barSpacing: 0.1,
+    xScale: d3.scale.ordinal()
   });
 
   constructor (props) {
-
-    console.log('>>>>>> DBC props:', props);
-
     super(props);
     this.chartConstructor = DiscreteBarChartImpl;
-
   }
 
   getClassSuffix () {
-    return 'barchart';
+    return 'barchart vertical';
   }
 
 }
 
 export class DiscreteBarChartImpl extends ChartBase {
 
-  constructor (selection) {
+  constructor (selection, props) {
 
-    super(selection);
+    super(selection, props);
 
     let _Chart = this;
 
-    this.configs['barSpacing'] = {value: 0.1};
+    this.configs['barSpacing'] = { value: props.barSpacing };
 
     // append group to chart
     let bars = this.baseLayer = this.base.append('g').classed('bars', true);
 
-
-
-    // TODO: WHY IS THIS HERE????
-    // this.updateDimensions();
-
-
+    this.updateDimensions();
 
     // define layer
     let layer = this.layer('bars', bars, {
@@ -60,16 +51,16 @@ export class DiscreteBarChartImpl extends ChartBase {
       insert: function () {
         return this.append('rect')
           .attr('class', 'bar')
-          .attr('width', _Chart.xScale.rangeBand());
+          .attr('width', _Chart.config('xScale').rangeBand());
       }
     });
 
     // Set up lifecycle events on layers
     layer.on('enter', function () {
       return this
-        .attr('x', d => _Chart.xScale(_Chart.accessor('x')(d)))
-        .attr('y', d => _Chart.yScale(_Chart.accessor('y')(d)))
-        .attr('height', d => _Chart._height - _Chart.yScale(_Chart.accessor('y')(d)));
+        .attr('x', d => _Chart.config('xScale')(_Chart.accessor('x')(d)))
+        .attr('y', d => _Chart.config('yScale')(_Chart.accessor('y')(d)))
+        .attr('height', d => _Chart._innerHeight - _Chart.config('yScale')(_Chart.accessor('y')(d)));
     })
     .on('merge', function () {
       // this => base selection
@@ -80,38 +71,20 @@ export class DiscreteBarChartImpl extends ChartBase {
 
   }
 
-  updateConfigs (props) {
-
-    // In React, default props are cached, and therefore non-primitives are shared across all instances.
-    // Therefore, we cannot rely on React to apply default non-primitive props;
-    // they must be set manually here.
-    props = _.merge(props, {
-      xScale: d3.scale.ordinal(),
-      yScale: d3.scale.linear()
-    });
-
-    super.updateConfigs(props);
-
-  }
-
   updateScales (data) {
 
-    this.xScale.rangeRoundBands([0, this._width], this.configs['barSpacing'].value);
-    this.yScale.range([this._height, 0]);
-    this.xScale.domain(data.map(d => this.accessor('x')(d)));
-    this.yScale.domain([0, d3.max(data, d => this.accessor('y')(d))]);
+    // TODO: I think this is a bug waiting to happen.
+    // When xScale and yScale are set from default React `props`,
+    // they point at a single instance of d3.scale that is
+    // shared across all instances. `props` should be considered immutable
+    // for this reason; however, this code will mutate the
+    // d3 scales used by all instances of DiscreteBarChart.
+    // Could the default prop instead be a factory function?
 
-  }
-
-  // Do something before `dataBind`
-  preDraw (data) {
-
-    super.preDraw(data);
-
-    if (this.yAxis) {
-      this.yAxis.config('orient', 'left');
-      this.yAxis.update();
-    }
+    this.config('xScale').rangeRoundBands([0, this._innerWidth], this.config('barSpacing'));
+    this.config('yScale').range([this._innerHeight, 0]);
+    this.config('xScale').domain(data.map(d => this.accessor('x')(d)));
+    this.config('yScale').domain([0, d3.max(data, d => this.accessor('y')(d))]);
 
   }
 

--- a/src/DiscreteBarChart/DiscreteBarChart.jsx
+++ b/src/DiscreteBarChart/DiscreteBarChart.jsx
@@ -23,7 +23,7 @@ export default class DiscreteBarChart extends PanoramaChart {
   }
 
   getClassSuffix () {
-    return 'barchart vertical';
+    return 'bar-chart vertical';
   }
 
 }

--- a/src/DiscreteBarChart/style.scss
+++ b/src/DiscreteBarChart/style.scss
@@ -1,4 +1,4 @@
-.panorama.barchart {
+.panorama.bar-chart {
   position: relative;
 
   .bar {

--- a/src/HorizontalDiscreteBarChart/HorizontalDiscreteBarChart.jsx
+++ b/src/HorizontalDiscreteBarChart/HorizontalDiscreteBarChart.jsx
@@ -18,7 +18,7 @@ export default class HorizontalDiscreteBarChart extends DiscreteBarChart {
   }
 
   getClassSuffix () {
-    return 'barchart horizontal';
+    return 'bar-chart horizontal';
   }
 
 }
@@ -37,24 +37,22 @@ export class HorizontalDiscreteBarChartImpl extends DiscreteBarChartImpl {
 
     super(selection, props);
 
-    let config = this.config.bind(this),
-      accessor = this.accessor.bind(this);
+    let _Chart = this;
 
     let layer = this.layer('bars');
 
     layer.insert = function () {
       return this.append('rect')
         .attr('class', 'bar')
-        .attr('height', config('yScale').rangeBand());
+        .attr('height', _Chart.config('yScale').rangeBand());
     };
-
 
     layer.on('enter', function () {
       return this
         .attr('x', d => '0')
-        .attr('y', d => config('yScale')(accessor('y')(d)))
-        .attr('width', d => config('xScale')(accessor('x')(d)))
-        .attr('height', config('yScale').rangeBand());
+        .attr('y', d => _Chart.config('yScale')(_Chart.accessor('y')(d)))
+        .attr('width', d => _Chart.config('xScale')(_Chart.accessor('x')(d)))
+        .attr('height', _Chart.config('yScale').rangeBand());
     });
 
   }
@@ -63,10 +61,10 @@ export class HorizontalDiscreteBarChartImpl extends DiscreteBarChartImpl {
 
     // TODO: I think this is a bug waiting to happen.
     // See TODO in DiscreteBarChart.updateScales().
-    this.config('yScale').rangeRoundBands([0, this._height], this.config('barSpacing'));
+    this.config('yScale').rangeRoundBands([0, this._innerHeight], this.config('barSpacing'));
     this.config('yScale').domain(data.map(d => this.accessor('y')(d)));
 
-    this.config('xScale').range([0, this._width]);
+    this.config('xScale').range([0, this._innerWidth]);
     this.config('xScale').domain([0, d3.max(data, d => this.accessor('x')(d))]);
 
   }

--- a/src/HorizontalDiscreteBarChart/HorizontalDiscreteBarChart.jsx
+++ b/src/HorizontalDiscreteBarChart/HorizontalDiscreteBarChart.jsx
@@ -1,28 +1,35 @@
 import d3 from 'd3';
 import DiscreteBarChart, { DiscreteBarChartImpl } from '../DiscreteBarChart/DiscreteBarChart';
+import _ from 'lodash';
 
 export default class HorizontalDiscreteBarChart extends DiscreteBarChart {
 
+  // 'inherit' static validatorsand defaults
+  static propTypes = _.merge(DiscreteBarChart.propTypes);
+  static defaultProps = _.merge(DiscreteBarChart.defaultProps);
+
   constructor (props) {
+
     super(props);
     this.chartConstructor = HorizontalDiscreteBarChartImpl;
+
   }
 
-  makeClassName () {
-    return 'panorama chart barchart';
+  getClassSuffix () {
+    return 'barchart';
   }
 
 }
 
-
 export class HorizontalDiscreteBarChartImpl extends DiscreteBarChartImpl {
+
   constructor (selection) {
+
     super(selection);
 
-    var _Chart = this;
-    this.yScale = d3.scale.ordinal();
-    this.xScale = d3.scale.linear();
-    var layer = this.layer('bars');
+    let _Chart = this;
+
+    let layer = this.layer('bars');
 
     layer.insert = function () {
       return this.append('rect')
@@ -33,23 +40,36 @@ export class HorizontalDiscreteBarChartImpl extends DiscreteBarChartImpl {
 
     layer.on('enter', function () {
       return this
-        .attr('x', function(d) { return '0'; })
-        .attr('y', function(d) { return _Chart.yScale(_Chart.accessor('y')(d)); })
-        .attr('width', function(d) { return _Chart.xScale(_Chart.accessor('x')(d)); })
+        .attr('x', d => '0')
+        .attr('y', d => _Chart.yScale(_Chart.accessor('y')(d)))
+        .attr('width', d => _Chart.xScale(_Chart.accessor('x')(d)))
         .attr('height', _Chart.yScale.rangeBand());
     });
+
+  }
+
+  updateConfigs (props) {
+    
+    // In React, default props are cached, and therefore non-primitives are shared across all instances.
+    // Therefore, we cannot rely on React to apply default non-primitive props;
+    // they must be set manually here.
+    props = _.merge(props, {
+      xScale: d3.scale.linear(),
+      yScale: d3.scale.ordinal()
+    });
+
+    super.updateConfigs(props);
+
   }
 
   updateScales (data) {
-    var _Chart = this;
+
     this.yScale.rangeRoundBands([0, this._height], this.configs['barSpacing'].value);
-    this.yScale.domain(data.map(function(d) { return _Chart.accessor('y')(d); }));
+    this.yScale.domain(data.map(d => this.accessor('y')(d)));
 
     this.xScale.range([0, this._width]);
-    this.xScale.domain([0, d3.max(data, function(d) { return _Chart.accessor('x')(d); })]);
+    this.xScale.domain([0, d3.max(data, d => this.accessor('x')(d))]);
 
-    if (this.xAxis) this.xAxis.config('scale', this.xScale);
-    if (this.yAxis) this.yAxis.config('scale', this.yScale);
   }
 
 }

--- a/src/MapChoropleth/MapChoropleth.jsx
+++ b/src/MapChoropleth/MapChoropleth.jsx
@@ -13,9 +13,9 @@ export default class MapChoropleth extends PanoramaChart {
 
 export class MapChoroplethImpl extends Koto {
 
-  constructor (selection) {
+  constructor (selection, props) {
 
-    super(selection);
+    super(selection, props);
 
     var _Chart = this;
 

--- a/src/MapChoropleth/MapChoropleth.jsx
+++ b/src/MapChoropleth/MapChoropleth.jsx
@@ -1,12 +1,34 @@
+import { PropTypes } from 'react';
 import d3 from 'd3';
 import Koto from 'koto';
 import PanoramaChart from '../charts/PanoramaChart';
 
 export default class MapChoropleth extends PanoramaChart {
 
+  // TODO: create a MapBase class, similar to ChartBase?
+  // TODO: pass in accessors for more flexibility with data?
+
+  // extend superclass `props` validators
+  static propTypes = Object.assign({}, PanoramaChart.propTypes, {
+    range: PropTypes.arrayOf(PropTypes.string),
+    projection: PropTypes.string,
+    mapScale: PropTypes.number
+  });
+
+  // extend superclass `props` defaults
+  static defaultProps = Object.assign({}, PanoramaChart.defaultProps, {
+    range: ['#EDF8FB', '#BFD3E6', '#9EBCDA', '#8C96C6', '#8C6BB1','#88419D', '#6E016B'],
+    projection: 'albersUsa',
+    mapScale: 500
+  });
+
   constructor (props) {
     super(props);
     this.chartConstructor = MapChoroplethImpl;
+  }
+
+  getClassSuffix () {
+    return 'map choropleth';
   }
 
 }
@@ -15,19 +37,21 @@ export class MapChoroplethImpl extends Koto {
 
   constructor (selection, props) {
 
-    super(selection, props);
+    super(selection);
+
+    Object.assign(this.configs, {
+      width: { value: props.width },
+      height: { value: props.height },
+      margin: { value: props.margin },
+      range: { value: props.range },
+      projection: { value: props.projection },
+      mapScale: { value: props.mapScale }
+    });
 
     var _Chart = this;
 
-    this.configs['width'] = {value: 600};
-    this.configs['height'] = {value: 400};
-    this.configs['margin'] = {value: {top: 20, right: 30, bottom: 20, left: 30}};
-    this.configs['range'] = {value: ['#EDF8FB', '#BFD3E6', '#9EBCDA', '#8C96C6', '#8C6BB1','#88419D', '#6E016B']};
-    this.configs['projection'] = {value: 'albersUsa'};
-    this.configs['mapScale'] = {value: 500};
-
     this._path = d3.geo.path();
-    this._projection = d3.geo[this.configs['projection'].value]();
+    this._projection = d3.geo[this.config('projection')]();
 
     this.data = {
       geometry: [],
@@ -35,7 +59,7 @@ export class MapChoroplethImpl extends Koto {
     };
 
     this.colorScale = d3.scale.quantize()
-      .range(this.configs['range'].value);
+      .range(this.config('range'));
 
     this.baseLayer = this.base.append('g').classed('map', true);
 
@@ -48,7 +72,7 @@ export class MapChoroplethImpl extends Koto {
         _Chart.data.values = data.values;
 
         return this.selectAll('path')
-                       .data(_Chart.data.geometry.features);
+          .data(_Chart.data.geometry.features);
       },
       insert: function () {
         return this.append('path')
@@ -60,7 +84,7 @@ export class MapChoroplethImpl extends Koto {
 
     // Setup life-cycle events on layers
     layer.on('enter', function () {
-
+      // this => enter selection
     })
     .on('merge', function () {
       // this => base selection
@@ -72,50 +96,57 @@ export class MapChoroplethImpl extends Koto {
   }
 
   fitMap (geo) {
-    var projection = d3.geo[this.configs['projection'].value]()
+    var projection = d3.geo[this.config('projection')]()
       .scale(1)
       .translate([0, 0]);
 
     var path = d3.geo.path()
       .projection(projection);
 
-    var width = this._width,
-      height = this._height;
-
     var b = path.bounds(geo),//[[left,top],[right,bottom]],
-      s = .95 / Math.max((b[1][0] - b[0][0]) / width, (b[1][1] - b[0][1]) / height),
-      t = [(width - s * (b[1][0] + b[0][0])) / 2, (height - s * (b[1][1] + b[0][1])) / 2];
+      s = .95 / Math.max((b[1][0] - b[0][0]) / this._innerWidth, (b[1][1] - b[0][1]) / this._innerHeight),
+      t = [(this._innerWidth - s * (b[1][0] + b[0][0])) / 2, (this._innerHeight - s * (b[1][1] + b[0][1])) / 2];
 
     return [s,t];
   }
 
+  /**
+   * Default implementation of d3-style 'conventional margins'
+   * (sim. to: http://bl.ocks.org/mbostock/3019563)
+   */
   updateDimensions () {
-    var margin = this.configs['margin'].value;
-    this._width = this.configs['width'].value - margin.left - margin.right;
-    this._height = this.configs['height'].value - margin.top - margin.bottom;
 
-    this.base.attr('height', this.configs['height'].value);
-    this.base.attr('width', this.configs['width'].value);
+    let margin = this.config('margin');
+
+    this._innerWidth = this.config('width') - margin.left - margin.right;
+    this._innerHeight = this.config('height') - margin.top - margin.bottom;
+
+    this.base.attr('width', this.config('width'));
+    this.base.attr('height', this.config('height'));
 
     this.baseLayer.attr('transform', 'translate(' + margin.left + ',' + margin.top + ')');
+
   }
 
   updateProjection (data) {
-    let scale = this.configs['mapScale'].value;
-    let translate = [this._width/2, this._height/2];
 
-    if (this.configs['mapScale'].value === 'auto') {
+    let scale = this.config('mapScale');
+    let translate = [this._innerWidth/2, this._innerHeight/2];
+
+    if (this.config('mapScale') === 'auto') {
       [scale, translate] = this.fitMap(data.geometry);
     }
 
-    this._projection = d3.geo[this.configs['projection'].value]()
+    this._projection = d3.geo[this.config('projection')]()
         .scale(scale)
         .translate(translate);
 
     this._path.projection(this._projection);
+
   }
 
   updateColorScale (data) {
+
     let max = -Infinity;
     for (let value of data.values.values()) {
       if (value > max) max = value;
@@ -123,13 +154,16 @@ export class MapChoroplethImpl extends Koto {
 
     this.colorScale
       .domain([0, max])
-      .range(this.configs['range'].value);
+      .range(this.config('range'));
+
   }
 
   preDraw (data) {
+
     this.updateDimensions();
     this.updateProjection(data);
     this.updateColorScale(data);
+
   }
 
 }

--- a/src/charts/Axis.js
+++ b/src/charts/Axis.js
@@ -2,7 +2,9 @@ import d3 from 'd3';
 import Koto from 'koto';
 
 export default class Axis extends Koto {
-  constructor(selection, axisType){
+
+  constructor (selection, axisType) {
+
     super(selection);
 
     this.configs['scale'] = {value: d3.scale.linear()};
@@ -12,9 +14,11 @@ export default class Axis extends Koto {
 
     this.axis = d3.svg.axis();
     this.baseLayer = this.base.append('g').classed(axisType + ' axis', true);
+
   }
 
-  update() {
+  update () {
+
     this.axis
       .scale(this.configs['scale'].value)
       .ticks(this.configs['ticks'].value)
@@ -25,5 +29,7 @@ export default class Axis extends Koto {
     this.baseLayer
       .attr('transform', 'translate(' + offset[0] + ',' + offset[1] + ')')
       .call(this.axis);
+
   }
+  
 }

--- a/src/charts/Axis.js
+++ b/src/charts/Axis.js
@@ -3,28 +3,35 @@ import Koto from 'koto';
 
 export default class Axis extends Koto {
 
-  constructor (selection, axisType) {
+  constructor (selection, axisType, props) {
 
     super(selection);
 
-    this.configs['scale'] = {value: d3.scale.linear()};
-    this.configs['ticks'] = {value: 5};
-    this.configs['orient'] = {value: 'bottom'};
-    this.configs['offset'] = {value: [0,0]};
+    this.configs['scale'] = { value: props.scale };
+    this.configs['ticks'] = { value: props.ticks };
+    this.configs['orient'] = { value: props.orient };
+    this.configs['offset'] = { value: props.offset };
 
     this.axis = d3.svg.axis();
     this.baseLayer = this.base.append('g').classed(axisType + ' axis', true);
 
   }
 
-  update () {
+  update (scale, offset) {
+
+    if (scale) {
+      this.config('scale', scale);
+    }
+    if (offset) {
+      this.config('offset', offset);
+    } else {
+      offset = this.config('offset');
+    }
 
     this.axis
-      .scale(this.configs['scale'].value)
-      .ticks(this.configs['ticks'].value)
-      .orient(this.configs['orient'].value);
-
-    var offset = this.configs['offset'].value;
+      .scale(this.config('scale'))
+      .ticks(this.config('ticks'))
+      .orient(this.config('orient'));
 
     this.baseLayer
       .attr('transform', 'translate(' + offset[0] + ',' + offset[1] + ')')

--- a/src/charts/ChartBase.js
+++ b/src/charts/ChartBase.js
@@ -1,32 +1,101 @@
 import d3 from 'd3';
 import Koto from 'koto';
 import Axis from './Axis';
+import _ from 'lodash';
 
 export default class ChartBase extends Koto {
-  constructor(selection){
-    super(selection);
 
-    this.configs['width'] = {value: 600};
-    this.configs['height'] = {value: 400};
-    this.configs['margin'] = {value: {top: 20, right: 30, bottom: 20, left: 30}};
+  constructor (selection) {
+
+    super(selection);
 
     this.xAxis = new Axis(this.base, 'x');
     this.yAxis = new Axis(this.base, 'y');
 
-    this.xScale = d3.scale.ordinal();
-    this.yScale = d3.scale.linear();
   }
 
-  updateScales(data) {
+  updateConfigs (props) {
+
+    // In React, default props are cached, and therefore non-primitives are shared across all instances.
+    // Therefore, we cannot rely on React to apply default non-primitive props;
+    // they must be set manually here.
+    props = _.merge(props, {
+      margin: { value: { top: 0, right: 0, bottom: 0, left: 0 } },
+      xAccessor: d => d.key,
+      yAccessor: d => d.value,
+      xScale: d3.scale.linear(),
+      yScale: d3.scale.linear()
+    });
+
+    this
+      .config('height', props.height)
+      .config('width', props.width)
+      .config('margin', props.margin)
+      .config('xScale', props.xScale)
+      .config('yScale', props.yScale)
+      .accessor('x', props.xAccessor)
+      .accessor('y', props.yAccessor)
+      .draw(props.data);
+      
+  }
+
+  /**
+   * Default implementation of d3-style 'conventional margins'
+   * (sim. to: http://bl.ocks.org/mbostock/3019563)
+   */
+  updateDimensions () {
+
+    let margin = this.configs['margin'].value;
+
+    this._width = this.configs['width'].value - margin.left - margin.right;
+    this._height = this.configs['height'].value - margin.top - margin.bottom;
+
+    this.base.attr('height', this.configs['height'].value);
+    this.base.attr('width', this.configs['width'].value);
+
+    this.baseLayer.attr('transform', 'translate(' + margin.left + ',' + margin.top + ')');
+
+    if (this.xAxis) this.xAxis.config('offset', [margin.left, this._height + margin.bottom]);
+    if (this.yAxis) this.yAxis.config('offset', [margin.left, margin.top]);
 
   }
 
-  updateDimensions() {
+  updateScales (data) {
+
+    this.xScale.range([0, this._width]);
+    this.yScale.range([this._height, 0]);
+
+    // default to set domain to all xAccesssor values along x-axis,
+    // and 0 <> max yAccessor value along y-axis.
+    this.xScale.domain(data.map(d => this.accessor('x')(d)));
+    this.yScale.domain([0, d3.max(data, d => this.accessor('y')(d))]);
 
   }
 
-  destroy() {
+  updateAxes () {
+
+    if (this.xAxis) this.xAxis.config('scale', this.xScale);
+    if (this.yAxis) this.yAxis.config('scale', this.yScale);
+
+  }
+
+  // Do something before `dataBind`
+  preDraw (data) {
+
+    this.updateDimensions();
+    this.updateScales(data);
+    this.updateAxes();
+
+    if (this.xAxis) this.xAxis.update();
+    if (this.yAxis) this.yAxis.update();
+
+  }
+
+  destroy () {
+
     this.base.remove();
     this.base = null;
+
   }
+
 }

--- a/src/charts/ChartBase.js
+++ b/src/charts/ChartBase.js
@@ -36,8 +36,7 @@ export default class ChartBase extends Koto {
       .config('xScale', props.xScale)
       .config('yScale', props.yScale)
       .accessor('x', props.xAccessor)
-      .accessor('y', props.yAccessor)
-      .draw(props.data);
+      .accessor('y', props.yAccessor);
 
   }
 

--- a/src/charts/PanoramaChart.jsx
+++ b/src/charts/PanoramaChart.jsx
@@ -79,7 +79,12 @@ export default class PanoramaChart extends React.Component {
     if (!this.chart) {
       this.chart = new this.chartConstructor(d3.select(this.refs.chart), this.props);
     }
-    this.chart.updateConfigs(this.props);
+
+    if (this.chart.updateConfigs) {
+      this.chart.updateConfigs(this.props);
+    }
+
+    this.chart.draw(this.props.data);
 
   }
 

--- a/src/charts/PanoramaChart.jsx
+++ b/src/charts/PanoramaChart.jsx
@@ -1,25 +1,19 @@
 import React, { PropTypes } from 'react';
 
+const BASE_CLASS_NAME = 'panorama chart ';
+
 export default class PanoramaChart extends React.Component {
 
   static propTypes = {
     data: PropTypes.oneOfType([PropTypes.array,PropTypes.object]),
-    xAccessor: PropTypes.func,
-    yAccessor: PropTypes.func,
     width: PropTypes.number,
-    height: PropTypes.number,
-    margin: PropTypes.object,
-    barSpacing: PropTypes.number
+    height: PropTypes.number
   }
 
   static defaultProps = {
     data: [],
     width: 600,
     height: 400,
-    margin: {top: 0, right: 0, bottom: 0, left: 0},
-    barSpacing: 0.1,
-    xAccessor: function(d){return d.key;},
-    yAccessor: function(d){return d.value;}
   }
 
   constructor (props) {
@@ -53,29 +47,30 @@ export default class PanoramaChart extends React.Component {
       this.chart = new this.chartConstructor(d3.select(this.refs.chart));
     }
 
-    this.chart
-      .config('height', this.props.height)
-      .config('width', this.props.width)
-      .accessor('x', this.props.xAccessor)
-      .accessor('y', this.props.yAccessor)
-      .draw(this.props.data);
+    // Pass in a mutable shallow copy of this.props,
+    // so it can be modified and defaults can be added as needed.
+    let propsCopy = {};
+    Object.keys(this.props).forEach(key => {
+      propsCopy[key] = this.props[key];
+    });
+    this.chart.updateConfigs(propsCopy);
 
   }
 
   /**
-   * Determine class name to be applied to container element.
+   * Determine class name to be appended to container element.
    * Typically overridden by subclasses.
    */
-  makeClassName () {
+  getClassSuffix () {
 
-    return 'panorama chart';
+    return '';
     
   }
 
   render () {
 
     return (
-      <div className={this.makeClassName()}>
+      <div className={ BASE_CLASS_NAME + this.getClassSuffix() }>
         <svg ref='chart' className='wrapper'></svg>
       </div>
     );

--- a/src/charts/PanoramaChart.jsx
+++ b/src/charts/PanoramaChart.jsx
@@ -7,13 +7,46 @@ export default class PanoramaChart extends React.Component {
   static propTypes = {
     data: PropTypes.oneOfType([PropTypes.array,PropTypes.object]),
     width: PropTypes.number,
-    height: PropTypes.number
+    height: PropTypes.number,
+    margin: PropTypes.shape({
+      top: PropTypes.number,
+      right: PropTypes.number,
+      bottom: PropTypes.number,
+      left: PropTypes.number
+    }),
+    xScale: PropTypes.func,
+    yScale: PropTypes.func,
+    xAccessor: PropTypes.func,
+    yAccessor: PropTypes.func,
+    axisProps: PropTypes.shape({
+      scale: PropTypes.func,
+      ticks: PropTypes.number,
+      orient: PropTypes.string,
+      offset: PropTypes.array
+    })
   }
 
   static defaultProps = {
     data: [],
     width: 600,
     height: 400,
+    margin: {
+      top: 20,
+      right: 30,
+      bottom: 20,
+      left: 30
+    },
+    xScale: d3.scale.linear(),
+    yScale: d3.scale.linear(),
+    xAccessor: d => d.key,
+    yAccessor: d => d.value,
+    axisProps: {
+      scale: d3.scale.linear(),
+      ticks: 5,
+      xOrient: 'bottom',
+      yOrient: 'left',
+      offset: [0, 0]
+    }
   }
 
   constructor (props) {
@@ -44,16 +77,9 @@ export default class PanoramaChart extends React.Component {
   update () {
 
     if (!this.chart) {
-      this.chart = new this.chartConstructor(d3.select(this.refs.chart));
+      this.chart = new this.chartConstructor(d3.select(this.refs.chart), this.props);
     }
-
-    // Pass in a mutable shallow copy of this.props,
-    // so it can be modified and defaults can be added as needed.
-    let propsCopy = {};
-    Object.keys(this.props).forEach(key => {
-      propsCopy[key] = this.props[key];
-    });
-    this.chart.updateConfigs(propsCopy);
+    this.chart.updateConfigs(this.props);
 
   }
 

--- a/src/main.js
+++ b/src/main.js
@@ -1,15 +1,17 @@
 'use strict';
 
-import Legend from './Legend/Legend';
-import Punchcard from './Punchcard/Punchcard';
+import AreaChart from './AreaChart/AreaChart';
 import DiscreteBarChart from './DiscreteBarChart/DiscreteBarChart';
 import HorizontalDiscreteBarChart from './HorizontalDiscreteBarChart/HorizontalDiscreteBarChart';
+import Legend from './Legend/Legend';
 import MapChoropleth from './MapChoropleth/MapChoropleth';
+import Punchcard from './Punchcard/Punchcard';
 
 export default {
-  Legend,
-  Punchcard,
+  AreaChart,
   DiscreteBarChart,
   HorizontalDiscreteBarChart,
-  MapChoropleth
+  Legend,
+  MapChoropleth,
+  Punchcard
 };

--- a/src/webpack.config.js
+++ b/src/webpack.config.js
@@ -9,7 +9,7 @@ module.exports = {
 
   debug: process.env.NODE_ENV !== 'production',
 
-  devtool: 'sourcemap',
+  devtool: 'source-map',
 
   entry: './main.js',
 


### PR DESCRIPTION
Also a lot of refactoring Koto charts from the `this.configs['valueName'].value` pattern to `this.config('valueName')`.

Also adds the AreaChart component.
