### PR TITLE
Keep lodash out of the resulting bundle

### DIFF
--- a/package.json
+++ b/package.json
@@ -62,7 +62,10 @@
     "webpack-merge": "^0.2.0"
   },
   "dependencies": {
-    "lodash": "^3.10.1"
+    "lodash.assign": "^3.2.0",
+    "lodash.isarray": "^3.0.4",
+    "lodash.isobject": "^3.0.2",
+    "lodash.pick": "^3.1.0"
   },
   "peerDependencies": {
     "cartodb-client": "stamen/cartodb-client",

--- a/src/Leaflet/Choropleth/Choropleth.jsx
+++ b/src/Leaflet/Choropleth/Choropleth.jsx
@@ -1,10 +1,10 @@
 import React, {PropTypes, Children} from 'react';
 import { MapLayer } from 'react-leaflet';
 import { geoJson, DomEvent } from 'leaflet';
-import pick from 'lodash/object/pick';
-import isObject from 'lodash/lang/isObject';
-import isArray from 'lodash/lang/isArray';
-import assign from 'lodash/object/assign';
+import pick from 'lodash.pick';
+import isObject from 'lodash.isobject';
+import isArray from 'lodash.isarray';
+import assign from 'lodash.assign';
 
 const OPTIONS = [
   'stroke',

--- a/src/Leaflet/Tooltip/Tooltip.jsx
+++ b/src/Leaflet/Tooltip/Tooltip.jsx
@@ -1,7 +1,7 @@
 import { PropTypes } from 'react';
 import {Popup, PropTypes as LeafletPropTypes } from 'react-leaflet';
 import { Map, popup } from 'leaflet';
-import assign from 'lodash/object/assign';
+import assign from 'lodash.assign';
 
 export default class Tooltip extends Popup {
   static propTypes = {

--- a/src/webpack.config.js
+++ b/src/webpack.config.js
@@ -4,17 +4,6 @@ var path = require('path');
 var webpack = require('webpack');
 var ExtractTextPlugin = require('extract-text-webpack-plugin');
 
-/*
-  TODO: Keep `lodash` out of bundle
-  Tried adding the below to externals but didn't work.
-    'lodash': {
-      commonjs: 'lodash',
-      commonjs2: 'lodash',
-      amd: '_',
-      root: '_'
-    }
-*/
-
 module.exports = {
   context: __dirname,
 
@@ -32,6 +21,10 @@ module.exports = {
       'd3': 'd3',
       'intro.js': 'intro.js',
       'leaflet': 'leaflet',
+      'lodash.assign': true,
+      'lodash.isarray': true,
+      'lodash.isobject': true,
+      'lodash.pick': true,
       'react': {
         root: 'React',
         commonjs: 'react',

--- a/src/webpack.config.modules.js
+++ b/src/webpack.config.modules.js
@@ -32,7 +32,10 @@ module.exports = {
       'd3': 'd3',
       'intro.js': 'intro.js',
       'leaflet': 'leaflet',
-      'lodash': 'lodash',
+      'lodash.assign': true,
+      'lodash.isarray': true,
+      'lodash.isobject': true,
+      'lodash.pick': true,
       'react': {
         root: 'React',
         commonjs: 'react',


### PR DESCRIPTION
Matching import/requires of nested resources might have worked, but this makes the use of lodash components more explicit.

I saw this so I fixed it:

``` javascript
/*
  TODO: Keep `lodash` out of bundle
  Tried adding the below to externals but didn't work.
    'lodash': {
      commonjs: 'lodash',
      commonjs2: 'lodash',
      amd: '_',
      root: '_'
    }
*/
```
