### PR TITLE
Improved kitchen sink build

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
     "build:dist": "npm run clean:dist && webpack --config ./src/webpack.config.dist.js && webpack --config ./src/webpack.config.dist.min.js",
     "clean:dist": "rm -rf ./dist/**",
     "clean:dist-modules": "rm -rf ./dist-modules/**",
-    "build:dist-modules": "npm run clean:dist-modules && webpack --config ./src/webpack.config.modules.js && babel ./src/main.js --out-file ./dist-modules/index.js",
+    "build:dist-modules": "npm run clean:dist-modules && webpack --config ./src/webpack.config.modules.js",
     "publish:dist": "./.bin/publish-dist.sh",
     "analyze": "webpack --json --config ./src/webpack.config.js | analyze-bundle-size"
   },

--- a/src/webpack.config.modules.js
+++ b/src/webpack.config.modules.js
@@ -14,12 +14,13 @@ module.exports = {
   debug: true,
   devtool: '#source-map',
 
-  // NOTE: when running this via `npm run build:dist-modules`
-  // you will need to edit the resulting index.js file
-  // to only include these two files
   entry: {
-    Legend: './Legend/Legend',
-    DiscreteBarChart: './DiscreteBarChart/DiscreteBarChart'
+    // main entrypoint (to load all components)
+    index: './main',
+
+    // individual components
+    Legend: ['./Legend/Legend'],
+    DiscreteBarChart: ['./DiscreteBarChart/DiscreteBarChart'],
   },
 
   eslint: {
@@ -74,7 +75,7 @@ module.exports = {
 
   output: {
     path: path.join(__dirname, '..', 'dist-modules'),
-    filename: '[name]/[name].js',
+    filename: '[name].js',
     library: ['@panorama/toolkit', '[name]'],
     libraryTarget: 'umd'
   },


### PR DESCRIPTION
Previously, the kitchen sink build (`dist-modules/index.js`) was merely transpiled from `src/main.js`, so it assumed CommonJS `require()`. This uses Webpack to create a UMD build.
