### PR TITLE
Standalone modules w/ source map support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -42,3 +42,4 @@ examples/public/examples.*
 # Distribution Modules
 dist-modules
 
+es5/

--- a/package.json
+++ b/package.json
@@ -2,8 +2,9 @@
   "name": "@panorama/toolkit",
   "version": "0.1.4",
   "description": "Panorama visualization toolkit",
-  "main": "dist/components.min.js",
+  "main": "es5/main.js",
   "scripts": {
+    "prepublish": "babel -s inline src/ -d es5/",
     "start": "npm run clean:examples && webpack-dev-server --config ./examples/webpack.config.js --hot --inline --content-base examples/public",
     "test": "jest",
     "lint": "eslint ./src",
@@ -62,7 +63,8 @@
     "webpack-merge": "^0.2.0"
   },
   "dependencies": {
-    "lodash": "^3.10.1"
+    "lodash": "^3.10.1",
+    "source-map-support": "^0.4.0"
   },
   "peerDependencies": {
     "cartodb-client": "stamen/cartodb-client",

--- a/src/main.js
+++ b/src/main.js
@@ -1,5 +1,7 @@
 'use strict';
 
+import 'source-map-support/register';
+
 // Panorama components.
 import AreaChart from './AreaChart/AreaChart';
 import CartoDBLoader from './CartoDBLoader/CartoDBLoader';


### PR DESCRIPTION
(For discussion)

For inclusion using `require`/`import` + npm-style dependency resolution (which can't assume a transpilation step, hence the use of `babel` in a `prepublish` script (which also runs after `npm install`, potentially obviating the need to include `dist/` in git)).

NOTE: this doesn't actually work due to direct `require()`ing of SASS:

```
> var main = require("./es5/main")
Error: Cannot find module './style.scss'
    at Function.Module._resolveFilename (module.js:337:15)
    at Function.Module._load (module.js:287:25)
    at Module.require (module.js:366:17)
    at require (module.js:385:17)
    at Object.<anonymous> (../../src/charts/D3ReactBase.jsx:2:60)
    at Module._compile (module.js:435:26)
    at Object.Module._extensions..js (module.js:442:10)
    at Module.load (module.js:356:32)
    at Function.Module._load (module.js:311:12)
    at Module.require (module.js:366:17)
```

It's also possible that the use of `source-map-support` may cause problems in non-V8-based browsers.
